### PR TITLE
fix name of image for sdlc/publish

### DIFF
--- a/sdlc/publish
+++ b/sdlc/publish
@@ -13,7 +13,7 @@ fi
 
 docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
 # Push optimistic tag.
-docker-compose push texlive
+docker-compose push octool
 docker logout
 
 echo


### PR DESCRIPTION
I had originally named the service "texlive" when creating the image,
but I changed mid-stream to "octool" for consistency with the tool.